### PR TITLE
Regression Testing feature, staging/testing environment config

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,26 @@ $ npm start -- --tokenfile <different token file>
 $ npm start -- --token <token>
 ```
 
+**To boot up the bot for hosting** (note: you can check your enviroment on the Bot's user's Listening To: tab):
+```
+# To be able to perform automative regression tests of the entire command list:
+# To run the command is !vb regression
+$ npm start -- --regression
+```
+
+**To boot up the bot for regression testing** (note: you can check your enviroment on the Bot's user's Listening To: tab):
+```
+# To be able to perform automative regression tests of the entire command list:
+# To run the command is !vb regression
+$ npm start -- --regression
+```
+
+**To ignore permission levels (admin commands)**
+```
+# If you start the bot with the following switch, it will ignore the privilege levels.
+$ npm start -- --ignoreowner
+```
+
+
+
 **To exit your hosting** of the bot press: 'Control' + 'C' in your terminal session while running the bot, or use the command !vb kill in your discord session


### PR DESCRIPTION
When running
$ npm start -- --regression

It'll allow the command **!vb regression** to be input.
Will run through an array of the commands, sets a timeout sesh to allow the command to run for 10 seconds, if the command isn't callable it will tell the user it's not a command added and will send a message telling the user to check the console logs (not sure if we need this information on the discord client, since we can already see it going wrong on our console logs..)

Also visible environment status on the discord client itself, it will show the bot listening to "in TEST" rather then the normal (and changed) prompt for the help command (!vb help). You cannot run !vb regression in release with this implementation as well.